### PR TITLE
fix(finance): start date logic to generate invoices

### DIFF
--- a/.sqlx/query-123f5b97dedafe6601f96f4602b3f7335e344837d2bef2f1e53887be58a93d48.json
+++ b/.sqlx/query-123f5b97dedafe6601f96f4602b3f7335e344837d2bef2f1e53887be58a93d48.json
@@ -21,7 +21,7 @@
       {
         "ordinal": 3,
         "name": "year",
-        "type_info": "Int2"
+        "type_info": "Int4"
       },
       {
         "ordinal": 4,
@@ -49,7 +49,7 @@
         "Uuid",
         "Text",
         "Int4",
-        "Int2",
+        "Int4",
         "Bool",
         "Timestamptz",
         "Timestamptz",

--- a/.sqlx/query-731a88a4bde1065199fe6c37fb97dc481ee4b0f10c4dc5f4d0fd66bada55d0c4.json
+++ b/.sqlx/query-731a88a4bde1065199fe6c37fb97dc481ee4b0f10c4dc5f4d0fd66bada55d0c4.json
@@ -21,7 +21,7 @@
       {
         "ordinal": 3,
         "name": "year",
-        "type_info": "Int2"
+        "type_info": "Int4"
       },
       {
         "ordinal": 4,

--- a/.sqlx/query-9bfc33280c327635d42ce2a8c52f82410f683c1b9fab0a19ade025a58aa49809.json
+++ b/.sqlx/query-9bfc33280c327635d42ce2a8c52f82410f683c1b9fab0a19ade025a58aa49809.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    invoice_id,\n                    title,\n                    month,\n                    year,\n                    is_main,\n                    created_at,\n                    updated_at,\n                    deleted_at\n                FROM invoices\n                WHERE\n                    year = $1\n                    AND month = $2\n                    AND is_main IS true\n            ",
+  "query": "\n                SELECT\n                    invoice_id,\n                    title,\n                    month,\n                    year,\n                    is_main,\n                    created_at,\n                    updated_at,\n                    deleted_at\n                FROM invoices\n                WHERE (year, month) IN (\n                    SELECT * FROM UNNEST($1::int[], $2::int[])\n                ) \n                AND is_main IS true\n            ",
   "describe": {
     "columns": [
       {
@@ -21,7 +21,7 @@
       {
         "ordinal": 3,
         "name": "year",
-        "type_info": "Int2"
+        "type_info": "Int4"
       },
       {
         "ordinal": 4,
@@ -46,8 +46,8 @@
     ],
     "parameters": {
       "Left": [
-        "Int2",
-        "Int4"
+        "Int4Array",
+        "Int4Array"
       ]
     },
     "nullable": [
@@ -61,5 +61,5 @@
       true
     ]
   },
-  "hash": "66c2ba1ad2dd87a23414238d8b148f8fa378fbac8786e14804ea4014c327e84d"
+  "hash": "9bfc33280c327635d42ce2a8c52f82410f683c1b9fab0a19ade025a58aa49809"
 }

--- a/.sqlx/query-be77451487781e3ba6c8ce71c679f850e71c181e19a3f1cc3e98590edec58988.json
+++ b/.sqlx/query-be77451487781e3ba6c8ce71c679f850e71c181e19a3f1cc3e98590edec58988.json
@@ -21,7 +21,7 @@
       {
         "ordinal": 3,
         "name": "year",
-        "type_info": "Int2"
+        "type_info": "Int4"
       },
       {
         "ordinal": 4,

--- a/.sqlx/query-d705d587427ccad8a89b854eedd1617ff18c8c5e8af5c941be1c833331a9d953.json
+++ b/.sqlx/query-d705d587427ccad8a89b854eedd1617ff18c8c5e8af5c941be1c833331a9d953.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                UPDATE \n                    invoices\n                SET\n                    title = $2,\n                    month = $3,\n                    year = $4\n                WHERE\n                    invoice_id = $1\n                RETURNING\n                    *\n            ",
+  "query": "\n                SELECT * FROM invoices WHERE year = $1 AND month = $2\n            ",
   "describe": {
     "columns": [
       {
@@ -46,8 +46,6 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text",
         "Int4",
         "Int4"
       ]
@@ -63,5 +61,5 @@
       true
     ]
   },
-  "hash": "259c4690d5295bae5cf5d73a0b457720670f3ca6db3e4e545e00fd3ce46c3e65"
+  "hash": "d705d587427ccad8a89b854eedd1617ff18c8c5e8af5c941be1c833331a9d953"
 }

--- a/migrations/20240905222804_init-finance-schema.sql
+++ b/migrations/20240905222804_init-finance-schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE invoices (
     invoice_id UUID PRIMARY KEY,
     title TEXT NOT NULL,
     month INT NOT NULL CHECK (month BETWEEN 1 AND 12),
-    year SMALLINT NOT NULL,
+    year INT NOT NULL,
     is_main BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at TIMESTAMP WITH TIME ZONE,

--- a/services/finance/src/domains/invoices.rs
+++ b/services/finance/src/domains/invoices.rs
@@ -10,7 +10,7 @@ pub struct Invoice {
     pub invoice_id: Uuid,
     pub title: String,
     pub month: i32,
-    pub year: i16,
+    pub year: i32,
     pub is_main: bool,
     pub created_at: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,7 +30,7 @@ impl Default for Invoice {
             invoice_id: Uuid::new_v4(),
             title: format!("Fatura de {} / {}", month_name.name(), year),
             month: month as i32,
-            year: year as i16,
+            year: year as i32,
             is_main: true,
             created_at: Utc::now(),
             updated_at: None,
@@ -40,6 +40,19 @@ impl Default for Invoice {
 }
 
 impl Invoice {
+    pub fn new(year: i32, month: i32, main: Option<bool>) -> Self {
+        Self {
+            invoice_id: Uuid::new_v4(),
+            title: format!("Fatura de {}/{}", month, year),
+            month,
+            year,
+            is_main: main.unwrap_or(false),
+            created_at: Utc::now(),
+            updated_at: None,
+            deleted_at: None,
+        }
+    }
+
     pub fn update(&mut self, payload: InvoiceUpdatePayload) {
         if let Some(title) = payload.title {
             self.title = title;
@@ -60,7 +73,7 @@ impl Invoice {
 pub struct InvoicePayload {
     pub title: String,
     pub month: i32,
-    pub year: i16,
+    pub year: i32,
     pub main_invoice: Option<Uuid>,
 }
 
@@ -92,7 +105,7 @@ impl From<InvoicePayload> for Invoice {
 pub struct InvoiceUpdatePayload {
     pub title: Option<String>,
     pub month: Option<i32>,
-    pub year: Option<i16>,
+    pub year: Option<i32>,
 }
 
 impl InvoiceUpdatePayload {

--- a/services/finance/src/main.rs
+++ b/services/finance/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
     );
 
     let port: u16 = std::env::var("PORT")
-        .unwrap_or_else(|_| "8080".to_string())
+        .unwrap_or_else(|_| "5010".to_string())
         .parse()
         .expect("PORT must be a number");
 


### PR DESCRIPTION
- adiciona uma logica para criação de faturas de um intervalo de uma data de corte específica; 
    - Antes estava sendo criada somente do `now` que é o mes atual da execução